### PR TITLE
Add option to use Actor art instead of Token texture. This fixes UI f…

### DIFF
--- a/src/lang/en.yml
+++ b/src/lang/en.yml
@@ -40,3 +40,5 @@ SETTINGS.SIMOC.SendRevealMessageName: Send Reveal Message
 SETTINGS.SIMOC.SendRevealMessageHint: Send a message when a chosen card is revealed.
 SETTINGS.SIMOC.WhisperRevealMessageName: Whisper Messages
 SETTINGS.SIMOC.WhisperRevealMessageHint: When enabled, the reveal messages are sent (whispered) only to the participants.
+SETTINGS.SIMOC.UseActorArtName: Use Actor art instead of token
+SETTINGS.SIMOC.UseActorArtHint: If token art is animated it may pose problems displaying inside UI. Use Actor art instead.

--- a/src/module/app.js
+++ b/src/module/app.js
@@ -22,6 +22,7 @@ import { getTokenOwner } from '@utils/token-utils';
  * @typedef {Object} Participant
  * @property {string}        id      The token's ID (read-only)
  * @property {TokenDocument} token
+ * @property {string}        participantArt
  * @property {User}          user
  * @property {Cards}         stack
  * @property {boolean}       isOwner
@@ -133,9 +134,10 @@ export default class CardChooser extends Application {
     const user = game.users.get(data.user);
     const stack = game.cards.get(data.stack);
     const card = stack.cards.get(data.card);
+    const participantArt = (game.settings.get(MODULE_ID, SETTINGS_KEYS.USE_ACTOR_ART_MESSAGE) ? token.actor.img : token.texture.src)
     // const isOwner = game.user.id === user.id;
     return {
-      token, user, stack, card,
+      token, user, stack, card, participantArt,
       revealed: !!data.revealed,
       get id() { return this.token.id; },
       get isOwner() { return this.user.id === game.user.id; },
@@ -317,7 +319,7 @@ export default class CardChooser extends Application {
 
     const tokenParticipants = tokens.map(t => ({
       id: t.id,
-      img: t.texture.src,
+      img: (game.settings.get(MODULE_ID, SETTINGS_KEYS.USE_ACTOR_ART_MESSAGE) ? t.actor.img : t.texture.src) ,
       name: t.name,
       checked: selectedTokenIds.includes(t.id),
       user: getTokenOwner(t, true),

--- a/src/module/constants.js
+++ b/src/module/constants.js
@@ -10,4 +10,5 @@ export const SETTINGS_KEYS = {
   /** @type {'addControlButton'} */ ADD_CONTROL_BUTTON: 'addControlButton',
   /** @type {'sendRevealMessage'} */ SEND_REVEAL_MESSAGE: 'sendRevealMessage',
   /** @type {'whisperRevealMessage'} */ WHISPER_REVEAL_MESSAGE: 'whisperRevealMessage',
+  /** @type {'useActorArtMessage'} */ USE_ACTOR_ART_MESSAGE: 'useActorArtMessage',
 };

--- a/src/module/settings.js
+++ b/src/module/settings.js
@@ -37,4 +37,12 @@ export function registerSystemSettings() {
     type: Boolean,
     default: true,
   });
+  game.settings.register(MODULE_ID, SETTINGS_KEYS.USE_ACTOR_ART_MESSAGE, {
+    name: 'SETTINGS.SIMOC.UseActorArtName',
+    hint: 'SETTINGS.SIMOC.UseActorArtHint',
+    scope: 'world',
+    config: true,
+    type: Boolean,
+    default: false,
+  });  
 }

--- a/src/templates/app.hbs
+++ b/src/templates/app.hbs
@@ -1,7 +1,7 @@
 <div class="participants">
 	{{#each participants}}
 		<div class="participant" data-participant-id="{{token.id}}">
-			<img class="participant-avatar" src="{{token.texture.src}}"/>
+			<img class="participant-avatar" src="{{participantArt}}"/>
 			<h3 class="participant-name">{{token.name}}</h3>
 			<div class="card{{#unless card}} nocard{{/unless}}{{#if (and isOwner ../isUnlocked)}} clickable{{/if}}">
 				{{#if card}}


### PR DESCRIPTION
…or animated tokens

## Summary
I have added option to settings that would switch usage of token texture to Actor art.
This change is transparent for current installations. Default behaviour is the old one.
This change would easily allow usage of plugin with animated tokens, which are currently not displayed inside UI.
Please note, I'm not javascript developer by trade, so please review and/or modify this PR to reflect best practices

## Checklist
- [x] added setting option
- [x] changed token art usage in two dialogs
- [x] tested briefly

### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR fixes an issue.
- [ ] This PR is not a code change (e.g. documentation, README, ...)

### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
