### PR TITLE
fix: Change hooks ready call event name

### DIFF
--- a/src/module/constants.js
+++ b/src/module/constants.js
@@ -15,5 +15,6 @@ export const SETTINGS_KEYS = {
 
 /** @enum {string} */
 export const HOOKS_KEYS = {
+  /** @type {'simultaneousCardsReady'} */ READY: 'simultaneousCardsReady',
   /** @type {'simultaneousCardsReveal'} */ REVEAL: 'simultaneousCardsReveal',
 };

--- a/src/simultaneous-cards.js
+++ b/src/simultaneous-cards.js
@@ -1,4 +1,4 @@
-import { MODULE_ID, MODULE_NAME, SETTINGS_KEYS } from '@module/constants';
+import { HOOKS_KEYS, MODULE_ID, MODULE_NAME, SETTINGS_KEYS } from '@module/constants';
 import { SIMOC } from '@module/config';
 import CardChooser from '@module/app';
 import { registerSystemSettings } from '@module/settings';
@@ -16,7 +16,7 @@ Hooks.on('init', () => {
 
 Hooks.on('ready', () => {
   console.log(`${MODULE_NAME} | Ready!`);
-  Hooks.callAll('simocReady', CONFIG.SIMOC);
+  Hooks.callAll(HOOKS_KEYS.READY, CONFIG.SIMOC);
   CardChooser.listen();
 });
 


### PR DESCRIPTION
BREAKING CHANGE

## Summary
<!-- Here goes a short summary about what the PR is about. -->
Just a small change to rename the following:
```js
Hooks.callAll('simocReady', ...
// -->
Hooks.callAll('simultaneousCardsReady', ...
```
In order to comply with Foundry good practices.

## Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [X]. -->

### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR fixes an issue.
- [ ] This PR is not a code change (e.g. documentation, README, ...)

### Other
- [X] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [X] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
